### PR TITLE
Test: Add testEqualsFeedbackSessionName (Resolve #58)

### DIFF
--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -346,4 +346,20 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         assertFalse(question.showResponsesTo.contains(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS));
     }
 
+    @Test
+    public void testEqualsFeedbackSessionName() {
+        FeedbackQuestionAttributes first = new FeedbackQuestionAttributes();
+        FeedbackQuestionAttributes snd = new FeedbackQuestionAttributes();
+
+        first.feedbackSessionName = "DemoFeedbackSessionName1";
+        snd.feedbackSessionName = "DemoFeedbackSessionName2";
+
+        // first.feedbackSessionName is not equal to snd.feedbackSessionName
+        boolean a = first.equals(snd);
+
+        snd.feedbackSessionName = "DemoFeedbackSessionName1";
+        // first.feedbackSessionName is equal to snd.feedbackSessionName
+        boolean b = first.equals(snd);
+        assertTrue(b);
+    }
 }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -348,6 +348,10 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
     @Test
     public void testEqualsFeedbackSessionName() {
+        // If feedbackSessionName is the same for both objects, equals should return true (when all other attributes are
+        // null). If feedbackSessionName is different for the two objects, equals should return false (when all other
+        // attributes are null).
+
         FeedbackQuestionAttributes first = new FeedbackQuestionAttributes();
         FeedbackQuestionAttributes snd = new FeedbackQuestionAttributes();
 

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -364,6 +364,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         snd.feedbackSessionName = "DemoFeedbackSessionName1";
         // first.feedbackSessionName is equal to snd.feedbackSessionName
         boolean b = first.equals(snd);
+        assertFalse(a);
         assertTrue(b);
     }
 }


### PR DESCRIPTION
Tests the behaviour of FeedbackQuestionAttributesTest::equals() related to differences in sessionName.
