### PR TITLE
 Test: Fix access level of testIsNameVisibleToInvalidInput (Resolve #84)

### DIFF
--- a/src/test/java/teammates/test/cases/logic/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponsesLogicTest.java
@@ -577,7 +577,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
     }
 
-    public void testIsNameVisibleToInvalidInput() {
+    private void testIsNameVisibleToInvalidInput() {
 
         // When the showRecipientNameTo contains no valid FeedbackParticipantType (i.e. INSTRUCTORS, OWN_TEAM_MEMBERS,
         // OWN_TEAM_MEMBERS_INCLUDING_SELF, RECEIVER, RECEIVER_TEAM_MEMBERS or STUDENTS), but at least one invalid type


### PR DESCRIPTION
Fix access level of testIsNameVisibleToInvalidInput to enable rundning the full test suite.